### PR TITLE
Implement profile page scraping job

### DIFF
--- a/src/jobs/profile_job.py
+++ b/src/jobs/profile_job.py
@@ -1,11 +1,84 @@
+"""Job for extracting data from individual profile pages.
+
+This job loads a staff member's profile page and retrieves the profile image
+URL and bio text.  The implementation relies on Playwright for page loading and
+DOM inspection, matching the rest of the crawler infrastructure.
+"""
+
 from dataclasses import dataclass
+import re
+from typing import Optional
+
+from playwright.async_api import Page
 
 from src.jobs.base_job import BaseJob
+from src.models import StaffMember
+from src.utils import _load_page, make_full_url
 
 
 @dataclass
 class ProfileJob(BaseJob):
+    """Process a single staff profile page"""
 
-    def process(self):
-        """Process staff directory job"""
-        print("Soon implemented")
+    async def process(self, page: Page) -> StaffMember:
+        """Load the profile page and extract image URL and biography"""
+
+        url = self.data.get("profile_link") or self.data.get("url")
+        if not url:
+            raise Exception("Profile URL missing")
+
+        await _load_page(page, url)
+
+        image_url = await self._extract_image(page, url)
+        bio_text = await self._extract_bio(page)
+
+        data = self.data.copy()
+        data["profile_image_link"] = image_url
+        data["bio"] = bio_text
+
+        return StaffMember(**data)
+
+    async def _extract_image(self, page: Page, page_url: str) -> Optional[str]:
+        """Extract profile image URL from page"""
+
+        selector = (
+            "div.sidearm-staff-member-bio-image img, "
+            "div.sidearm-common-bio-image img"
+        )
+
+        try:
+            img = page.locator(selector).first
+            if await img.count() > 0:
+                src = await img.get_attribute("src")
+                if src:
+                    return make_full_url(src, page_url)
+        except Exception:
+            pass
+
+        try:
+            og = page.locator("meta[property='og:image']").first
+            if await og.count() > 0:
+                content = await og.get_attribute("content")
+                if content:
+                    return content
+        except Exception:
+            pass
+
+        return None
+
+    async def _extract_bio(self, page: Page) -> str:
+        """Extract biography text from page"""
+
+        locator = page.locator("div.sidearm-common-bio-full").first
+        try:
+            if await locator.count() == 0:
+                return ""
+
+            html = await locator.inner_html()
+            html = re.sub(r"(?i)<br\s*/?>", "\n", html)
+            text = re.sub(r"<[^>]+>", "", html)
+            text = re.sub(r"\s+\n", "\n", text)
+            return text.strip()
+        except Exception:
+            return ""
+

--- a/src/profile_extractor.py
+++ b/src/profile_extractor.py
@@ -5,13 +5,14 @@ Updated to work with unified BaseJob system
 
 import asyncio
 import logging
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Optional
 
 from playwright.async_api import Page
 
 from src.config import BROWSER_TIMEOUT
 from src.jobs.base_job import BaseJob
 from src.models import StaffMember
+from src.utils import make_full_url
 
 
 class ProfileExtractor:
@@ -22,32 +23,38 @@ class ProfileExtractor:
 
     async def extract_profile_data(self, job: BaseJob, page: Page) -> Dict[str, Any]:
         """Extract data from a staff member's profile page"""
-        job_data = job.get_data()
-        self.logger.info(f"Extracting profile data for {job_data.staff_name}")
+        job_data = job.data
+        staff_name = job_data.get('name', '')
+        self.logger.info(f"Extracting profile data for {staff_name}")
 
         await self._load_profile_page(job, page)
 
-        profile_data = {}
+        profile_data: Dict[str, Any] = {}
 
         try:
+            image_url = await self._extract_profile_image(page, job_data.get('profile_link') or job_data.get('url'))
+            if image_url:
+                profile_data['profile_image_link'] = image_url
+
             paragraphs = await self._extract_page_paragraphs(page)
             if paragraphs:
                 profile_data['bio'] = max(paragraphs, key=len)
 
         except Exception as e:
-            self.logger.warning(f"Error extracting profile data for {job_data.staff_name}: {e}")
+            self.logger.warning(f"Error extracting profile data for {staff_name}: {e}")
             return {}
 
-        self.logger.info(f"Profile extraction completed for {job_data.staff_name}: "
-                         f"{len(profile_data)} data categories extracted")
+        self.logger.info(
+            f"Profile extraction completed for {staff_name}: {len(profile_data)} data categories extracted")
 
         return profile_data
 
     async def _load_profile_page(self, job: BaseJob, page: Page):
         """Load the profile page with error handling"""
+        url = job.data.get('profile_link') or job.data.get('url')
         try:
             response = await asyncio.wait_for(
-                page.goto(job.url, timeout=BROWSER_TIMEOUT, wait_until='domcontentloaded'),
+                page.goto(url, timeout=BROWSER_TIMEOUT, wait_until='domcontentloaded'),
                 timeout=BROWSER_TIMEOUT / 1000
             )
             if response.status != 200:
@@ -108,9 +115,39 @@ class ProfileExtractor:
 
         return paragraphs
 
+    async def _extract_profile_image(self, page: Page, page_url: str | None) -> Optional[str]:
+        """Extract profile image URL using common selectors"""
+        if not page_url:
+            page_url = ''
+
+        selector = (
+            "div.sidearm-staff-member-bio-image img, "
+            "div.sidearm-common-bio-image img"
+        )
+
+        try:
+            img = page.locator(selector).first
+            if await img.count() > 0:
+                src = await img.get_attribute('src')
+                if src:
+                    return make_full_url(src, page_url)
+        except Exception:
+            pass
+
+        try:
+            og = page.locator("meta[property='og:image']").first
+            if await og.count() > 0:
+                content = await og.get_attribute('content')
+                if content:
+                    return content
+        except Exception:
+            pass
+
+        return None
+
     def update_staff_member_with_profile_data(self, staff_member: StaffMember,
                                               profile_data: Dict[str, Any]) -> StaffMember:
         """Update staff member with extracted profile data"""
-        staff_member.profile_crawled = True
+        staff_member.profile_image_link = profile_data.get('profile_image_link')
         staff_member.bio = profile_data.get('bio', '')
         return staff_member


### PR DESCRIPTION
## Summary
- implement ProfileJob for scraping profile image and bio from staff profile pages using Playwright
- extend ProfileExtractor to support profile image scraping and update staff member records

## Testing
- `python -m py_compile src/jobs/profile_job.py src/profile_extractor.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894683675ec83338d272b65effdae25